### PR TITLE
Fix session name not saving locally on bot.create

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,16 +14,16 @@ var cio = function (user, key) {
 			}}, function (err, httpResponse, body) {
 				if (err) throw err;
 				if (JSON.parse(body).status == "success") {
-					this.nick = JSON.parse(body).nick;
-					callback(false, this.nick);					
+					this.setNick(JSON.parse(body).nick);
+					callback(false, this.nick);
 				}
 				else if (JSON.parse(body).status == "Error: reference name already exists") {
-					callback(false, this.nick);					
+					callback(false, this.nick);
 				}
 				else {
 					throw JSON.parse(body).status;
 				}
-			});
+			}.bind(this));
 	}
 
 	this.ask = function (input, callback) {


### PR DESCRIPTION
The callback to the create request wasn't bound to the original object.
Because of this, `this.nick` was never changed and subsequent `bot.ask` requests failed. This could be circumvented by setting the nick manually.
